### PR TITLE
Add NS/LS Payouts/LP/Overgrid to isk/hr

### DIFF
--- a/frontend/src/Pages/ISKh.js
+++ b/frontend/src/Pages/ISKh.js
@@ -101,7 +101,7 @@ function createPayoutTable() {
     ["AS (HS)", 18200000, 3500, 20],
     ["AS (LS/NS)", 26000000, 5000, 30],
     ["VG (HS)", 10395000, 1400, 10],
-    ["VG (LS/NS)", 15000000, 2000, 20],
+    ["VG (LS/NS)", 15000000, 2000, 15],
   ]) {
     for (var overgrid = 0; overgrid < 11; overgrid++) {
       const payoutFactor = 1 - 0.0725 * overgrid - 0.0025 * overgrid ** 2;

--- a/frontend/src/Pages/ISKh.js
+++ b/frontend/src/Pages/ISKh.js
@@ -94,10 +94,14 @@ function decodeData(encoded) {
 function createPayoutTable() {
   var result = {};
   for (const [siteType, payout, lp, normalGrid] of [
-    ["Mothership (highsec)", 63000000, 14000, 80],
-    ["HQ (highsec)", 31500000, 7000, 40],
-    ["AS (highsec)", 18200000, 3500, 20],
-    ["VG (highsec)", 10395000, 1400, 10],
+    ["Mothership (HS)", 63000000, 14000, 80],
+    ["Mothership (LS/NS)", 90000000, 20000, 120],
+    ["HQ (HS)", 31500000, 7000, 40],
+    ["HQ (LS/NS)", 45000000, 10000, 60],
+    ["AS (HS)", 18200000, 3500, 20],
+    ["AS (LS/NS)", 26000000, 5000, 30],
+    ["VG (HS)", 10395000, 1400, 10],
+    ["VG (LS/NS)", 15000000, 2000, 20],
   ]) {
     for (var overgrid = 0; overgrid < 11; overgrid++) {
       const payoutFactor = 1 - 0.0725 * overgrid - 0.0025 * overgrid ** 2;


### PR DESCRIPTION
Add Nullsec payouts to the isk/hr calculator. I was getting annoyed at having to add my LP after the fact and overgrid detection etc is a nice to have

I know NS isn't really in scope, but i run both, nice to just have the one calculator